### PR TITLE
Pascal Solution 4

### DIFF
--- a/PrimePascal/solution_4/Dockerfile
+++ b/PrimePascal/solution_4/Dockerfile
@@ -1,0 +1,12 @@
+FROM primeimages/freepascal:3.2.0 AS build
+
+WORKDIR /opt/app
+COPY *.pas .
+
+RUN fpc PrimePas4.pas -O2 -v0
+
+FROM ubuntu:20.04
+COPY --from=build /opt/app/PrimePas4 /opt/app/
+
+ENTRYPOINT [ "/opt/app/PrimePas4" ]
+ 

--- a/PrimePascal/solution_4/PrimePas4.pas
+++ b/PrimePascal/solution_4/PrimePas4.pas
@@ -1,0 +1,310 @@
+program PrimePas4;
+
+{$mode objfpc}{$H+}
+
+uses
+  {$if defined(linux) or defined(freebsd) or defined(darwin)}
+  cthreads,
+  {$endif}
+  SysUtils, fgl, CPUCountUtil;
+
+type
+  TSieveThreadParam = record
+    sieveSize: uint64;
+
+    runningThreads,
+    totalThreads,
+    passes: integer;
+
+    showValidation,
+    showResults,
+    terminateThreads: boolean;
+
+    startTime: int64;
+  end;
+
+  PSieveThreadParam = ^TSieveThreadParam;
+
+  TResultsDictionary = specialize TFPGMap<uint64, uint64>;
+
+  TBitsArr = array [0..high(uint32)] of uint32; // number of uint32 will be SieveSize/64 + 1 extra uint32 if SieveSize/2 (flags for odd numbers only)is not a multiple of 32
+  PBitsArr = ^TBitsArr;
+
+  { prime_sieve }
+  prime_sieve = class
+    private
+      sieveSize: uint64;
+      bits: PBitsArr;
+
+      procedure ClearBits(n, skip: uint64); inline;
+      function GetBit(n: uint64): boolean; inline;
+      function CountPrimes: uint64;
+      procedure PrintResults(showResults, showValidation: boolean; duration: double; passes, threads: integer);
+      function ValidateResults: boolean;
+
+    public
+      constructor Create(n: uint64);
+      destructor Destroy; override;
+      procedure RunSieve;
+  end;
+
+{ prime_sieve }
+
+constructor prime_sieve.Create(n: uint64);
+var
+  bitsArrSize: uint32; // 32 bits size array because each value is 32 bits (containing 32 flags for prime numbers)
+
+begin
+  sieveSize:=n;
+  //allocating bitsArrSize = sieveSize/64 uint32s on the heap to store the bits for odd numbers
+  bitsArrSize:=(n>>6) + ord((n and 31)<>0); //and extra uint32 is added in case sieveSize/2 is not a multiple of 32
+  bits:=GetMem(bitsArrSize*4); // 32 bits = 4 bytes
+  fillDWord(bits^[0], bitsArrSize, $FFFFFFFF); // setting bits to true
+end;
+
+destructor prime_sieve.Destroy;
+begin
+  FreeMem(bits);
+  inherited Destroy;
+end;
+
+procedure prime_sieve.ClearBits(n, skip: uint64);
+var
+  maxSize: uint64;
+
+begin
+  // dividing all values by 2 as we only store bits for odd numbers in the uint32 array
+  n:=n>>1;
+  skip:=skip>>1;
+  maxSize:=sieveSize>>1;
+
+  while n<=maxSize do
+  begin
+    bits^[n>>5]:=bits^[n>>5] and not(uint32(1) << (n and 31));
+    n+=skip;
+  end;
+end;
+
+function prime_sieve.GetBit(n: uint64): boolean;
+begin
+  result:=(bits^[n>>6] and (uint32(1) << ((n>>1) and 31)))<>0;
+end;
+
+procedure prime_sieve.RunSieve;
+var
+  num,
+  factor,
+  q: uint64;
+
+begin
+  factor:=3;
+  q:=trunc(sqrt(sieveSize));
+
+  while factor<=q do
+  begin
+    num:=factor;
+
+    while (num<=sieveSize) and not GetBit(num) do
+      num+=2;
+
+    if num>sieveSize then
+      break;
+
+    factor:=num;
+    ClearBits(factor*factor, factor+factor);
+    factor+=2;
+  end;
+end;
+
+function prime_sieve.CountPrimes: uint64;
+var
+  i,
+  count: uint64;
+
+begin
+  count:=ord(sieveSize>=2);
+
+  i:=3;
+
+  while i<=sieveSize do
+  begin
+    if GetBit(i) then
+      count+=1;
+
+    i+=2;
+  end;
+
+  result:=count;
+end;
+
+function prime_sieve.ValidateResults: boolean;
+const
+  PRIME_COUNTS: array [0..9, 0..1] of uint64 = (
+    (10, 4),
+    (100, 25),
+    (1000, 168),
+    (10000, 1229),
+    (100000, 9592),
+    (1000000, 78498),
+    (10000000, 664579),
+    (100000000, 5761455),
+    (1000000000, 50847534),
+    (10000000000, 455052511)
+  );
+
+var
+  i: integer;
+  resultsDictionary: TResultsDictionary;
+
+begin
+  resultsDictionary:=TResultsDictionary.Create;
+  resultsDictionary.Sorted:=true;
+
+  for i:=0 to high(PRIME_COUNTS) do
+     resultsDictionary.Add(PRIME_COUNTS[i,0], PRIME_COUNTS[i,1]);
+
+  if resultsDictionary.Find(sieveSize, i) then
+    result:=resultsDictionary.Data[i]=CountPrimes
+  else
+    result:=false;
+
+  resultsDictionary.Free;
+end;
+
+procedure prime_sieve.PrintResults(showResults, showValidation: boolean; duration: double; passes, threads: integer);
+var
+  count,
+  num: uint64;
+
+begin
+    if showResults and (sieveSize>=2) then
+      write('2, ');
+
+  count:=ord(sieveSize>=2);
+
+  num:=3;
+
+  while num<=sieveSize do
+  begin
+    if GetBit(num) then
+    begin
+      if showResults then
+         write(format('%d, ', [num]));
+
+      count+=1;
+    end;
+
+    num+=2;
+  end;
+
+  if showResults then
+    writeln;
+
+  if showValidation then
+  begin
+    writeln(format('Passes: %d, Theads: %d, Time: %.6f s, Avg: %.6f ms, Limit: %d, Counts: %d/%d, Valid: %s',[
+                   passes,
+                   threads,
+                   duration,
+                   duration*1000/passes, // displaying average in milliseconds
+                   sieveSize,
+                   count, CountPrimes,
+                   BoolToStr(validateResults, 'true', 'false')]));
+    writeln;
+  end;
+
+  writeln(format('olivierbrun;%d;%.6f;%d;algorithm=base,faithful=yes,bits=1', [passes, duration, threads]));
+end;
+
+// retrieve command line options
+procedure GetRequested(var lThreadsRequested, lSecondsRequested: longint; var lSizeRequested: uint64; var lShowResults, lShowValidation: boolean);
+var
+  numParam: longint;
+  lCommand: string;
+
+begin
+  lThreadsRequested:=GetSystemThreadCount;
+  lSecondsRequested:=5;
+  lSizeRequested:=1000000;
+  lShowResults:=false;
+  lShowValidation:=false;
+
+  for numParam:=1 to ParamCount do
+  begin
+    lCommand:=ParamStr(numParam);
+
+    case LowerCase(LeftStr(lCommand,2)) of
+      '-l': lShowResults:=true;
+      '-t': lThreadsRequested:=StrToIntDef(Trim(RightStr(lCommand, length(lCommand)-2)), 1);
+      '-d': lSecondsRequested:=StrToIntDef(Trim(RightStr(lCommand, length(lCommand)-2)), 5);
+      '-s': lSizeRequested:=StrToInt64Def(Trim(RightStr(lCommand, length(lCommand)-2)), 1000000);
+      '-v': lShowValidation:=true;
+    end;
+  end;
+end;
+
+// this is the function to spawn a thread
+function SieveThread(p: pointer): ptrint;
+var
+  sieve: prime_sieve;
+  lSieveThreadParam: PSieveThreadParam;
+
+begin
+  lSieveThreadParam:=p;
+  InterLockedIncrement(lSieveThreadParam^.runningThreads); // increment the running threads count
+  sieve:=nil;
+
+  // calculating primes until the main thread sets the terminateThreads to true
+  while not lSieveThreadParam^.terminateThreads do
+  begin
+    // if a sieve object exists destroy it
+    if assigned(sieve) then
+      FreeAndNil(sieve);
+
+    sieve:=prime_sieve.Create(lSieveThreadParam^.sieveSize); // instantiate a new sieve
+    sieve.runSieve; // run it
+    InterLockedIncrement(lSieveThreadParam^.passes); // the passes variable is shared among all threads, hence the use of the thread safe InterLockedIncrement instruction instead of directly doing a +=1 operation
+  end;
+
+  // displaying results if this is the latest thread to terminate
+  if lSieveThreadParam^.runningThreads=1 then
+     sieve.PrintResults(lSieveThreadParam^.showResults, lSieveThreadParam^.showValidation, (GetTickCount64-lSieveThreadParam^.startTime)/1000, lSieveThreadParam^.passes, lSieveThreadParam^.totalThreads);
+
+  sieve.Free;
+  InterLockedDecrement(lSieveThreadParam^.runningThreads); // decrement the running threads count
+  result:=0;
+end;
+
+var
+  sieveThreadParam: TSieveThreadParam;
+
+  numThread,
+  secondsRequested: longint;
+
+begin
+  GetRequested(sieveThreadParam.totalThreads, secondsRequested, sieveThreadParam.sieveSize, sieveThreadParam.showResults, sieveThreadParam.showValidation); // retrieving command line options
+
+  sieveThreadParam.passes:=0;
+  sieveThreadParam.runningThreads:=0;
+  sieveThreadParam.terminateThreads:=false;
+  sieveThreadParam.startTime:=GetTickCount64;
+
+  // spawning the requested threads
+  for numThread:=1 to sieveThreadParam.totalThreads do
+    BeginThread(@sieveThread, @sieveThreadParam);
+
+  while true do
+  begin
+    if (GetTickCount64-sieveThreadParam.startTime)/1000>=secondsRequested then
+    begin
+      sieveThreadParam.terminateThreads:=true;
+
+      // waiting for all running threads to terminate
+      repeat
+      until sieveThreadParam.runningThreads=0;
+
+      break;
+    end;
+  end;
+end.
+

--- a/PrimePascal/solution_4/README.md
+++ b/PrimePascal/solution_4/README.md
@@ -1,0 +1,130 @@
+# Object Pascal solution by olivierbrun
+
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Parallelism](https://img.shields.io/badge/Parallel-yes-green)
+![Bit count](https://img.shields.io/badge/Bits-1-green)
+
+This solution implements a multithreaded version written in freepascal (Object Pascal) using an array of 32 bits values to store flags for prime numbers.  
+As an array index is 32 bits max in FreePascal, with this approach the addressable bit range on an array storing 32 bits values is actually 2^64.
+Bits are used to flag odd numbers only, reducing the memory footprint by half.
+
+Benefits from this approach:
+
+- it passes the test with a sieve size of 10.000.000.000 (including on a Raspberry PI) or any range up to 2^64 - 1 (18.446.744.073.709.551.615), as long as the machine has sufficient memory space,
+- performance is significantly better on linux machines (about 33% in average) compared to what I was obtaining with solution 3. However, no performance change on Windows machines.
+- I've optimized and inlined the GetBit and ClearBits functions to provide some performance boost.
+
+(I've noticed that using GetMem to allocate memory on the heap for the array, provides better performances than using a setlength instruction in the constructor).
+
+### Solution:
+
+The following 3 simple principles are what has made this solution capable of truly handling 64 bits sieve sizes: 
+- bits are stored in an array of 32 bits values, each bit stores a flag for an odd number.
+- the Getbit(n) function retrieves a bit value using (pseudo code) ```bits[n >> 6] & (1 << ((n >> 1) & 31)))```, where  
+index=n >> 6 (divide by 64 = 2 * 32 as only odd numbers are flagged, and each array element is 32 bits), the bit for the ```&``` operation is shifted left by the modulo 32 of n/2
+- the ClearBits(n, skip) method loops from i=n/2 to sizeSize/2 and clears each bit using (pseudo code) ```bits[i>>5]&=~(1<<(i & 31))``` followed by ```i+=skip/2``` to take into account the fact that the bits array stores flags for odd numbers only.
+
+## Run instructions
+
+### On linux
+Execute the following commands from the implementation directory:
+```
+fpc PrimePas4.pas -O2 -v0
+./PrimePas4
+```
+### On Windows
+Execute the following commands from the implementation directory:
+```
+fpc PrimePas4.pas -O2 -v0
+PrimePas4
+```
+
+### Command line options when running the PrimePas program.
+All parameters are optional.
+````
+PrimePas4 [-d<Duration>] [-t<Threads count>] [-s<Sieve size>] [-l] [-v]
+-d: provides the ability to specify the duration
+-t: provides the ability to specify the number of threads
+-s: provides the ability to specify the sieve size
+-l: lists all found prime numbers when the latest thread is destroyed
+-v: displays validation results such as "Passes: 19794, Theads: 8, Time: 5.016000 s, Avg: 0.253410 ms, Limit: 1000000, Counts: 78498/78498, Valid: true"
+Default values are:
+Duration: 5
+Threads count: number of CPU cores calculated by the program
+SieveSize: 1000000
+````
+
+### Docker
+A Dockerfile has been provided.
+
+## Output
+### Result obtained on a Intel Core i7-7700HQ on Windows 10 (version 20H2 build 19042.1110)  
+1 thread: PrimePas4 -t1 -v
+```
+Passes: 5713, Theads: 1, Time: 5.000000 s, Avg: 0.875197 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;5713;5.000000;1;algorithm=base,faithful=yes,bits=1
+```
+8 threads: PrimePas4 -v
+```
+Passes: 19708, Theads: 8, Time: 5.000000 s, Avg: 0.253704 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;19708;5.000000;8;algorithm=base,faithful=yes,bits=1
+```
+16 threads: PrimePas4 -t16 -v
+```
+Passes: 20754, Theads: 16, Time: 5.031000 s, Avg: 0.242411 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;20754;5.031000;16;algorithm=base,faithful=yes,bits=1
+```
+32 threads: PrimePas4 -t32 -v
+```
+Passes: 21194, Theads: 32, Time: 5.000000 s, Avg: 0.235916 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;21194;5.000000;32;algorithm=base,faithful=yes,bits=1
+```
+64 threads: PrimePas4 -t64 -v
+```
+Passes: 21471, Theads: 64, Time: 5.000000 s, Avg: 0.232872 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;21471;5.000000;64;algorithm=base,faithful=yes,bits=1
+```
+
+#### Results obtained for 10 billions (we exceeds the 5 seconds limit, but it confirms that the solution works for large sieve sizes).  
+It's interesting to note that  when running multple threads for such large numbers the CPU utilization decreases to only 52%-58% after a while, so there might be room for improvement.
+
+1 thread: PrimePas4 -s10000000000 -t1 -v
+```
+Passes: 1, Theads: 1, Time: 37.234000 s, Avg: 37234.000000 ms, Limit: 10000000000, Counts: 455052511/455052511, Valid: true
+olivierbrun;1;37.234000;1;algorithm=base,faithful=yes,bits=1
+```
+8 threads: PrimePas4 -s10000000000 -t8 -v
+```
+Passes: 8, Theads: 8, Time: 201.344000 s, Avg: 25168.000000 ms, Limit: 10000000000, Counts: 455052511/455052511, Valid: true
+olivierbrun;8;201.344000;8;algorithm=base,faithful=yes,bits=1
+```
+
+### Result obtained on a Raspberry PI4 running Raspberry PI OS 64 bits (5.10.17-v8+) 
+1 thread: ./PrimePas4 -t1 -v
+```
+Passes: 2253, Theads: 1, Time: 5.000000 s, Avg: 2.219263 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;2253;5.000000;1;algorithm=base,faithful=yes,bits=1
+```
+4 threads: ./PrimePas4 -v
+```
+Passes: 6916, Theads: 4, Time: 5.001000 s, Avg: 0.723106 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;6916;5.001000;4;algorithm=base,faithful=yes,bits=1
+```
+8 threads: ./PrimePas4 -t8 -v
+```
+Passes: 7769, Theads: 8, Time: 5.004000 s, Avg: 0.644098 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;7769;5.004000;8;algorithm=base,faithful=yes,bits=1
+```
+16 threads: ./PrimePas4 -t16 -v
+```
+Passes: 8159, Theads: 16, Time: 5.009000 s, Avg: 0.613923 ms, Limit: 1000000, Counts: 78498/78498, Valid: true
+olivierbrun;8159;5.009000;16;algorithm=base,faithful=yes,bits=1
+```
+
+Just for the fun, here is the result obtained on the Raspberry PI 4 on 1 thread for a sieve size of 10 billions (CPU utilization was also only 50%-52% and memory usage 597.9MB).  
+./PrimePas4 -s10000000000 -t1 -v
+```
+Passes: 1, Theads: 1, Time: 258.352000 s, Avg: 258352.000000 ms, Limit: 10000000000, Counts: 455052511/455052511, Valid: true
+olivierbrun;1;258.352000;1;algorithm=base,faithful=yes,bits=1
+```

--- a/PrimePascal/solution_4/cpucountutil.pas
+++ b/PrimePascal/solution_4/cpucountutil.pas
@@ -1,0 +1,86 @@
+// utility to retrieve the number of cores availble on a machine
+unit CPUCountUtil;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  {$IF defined(linux)}
+  ctypes,
+  {$ELSEIF defined(freebsd) or defined(darwin)}
+  ctypes, sysctl,
+  {$ELSEIF defined(windows)}
+  Windows,
+    {$IFDEF UseTProcessW}
+    pipes,
+    {$ENDIF}
+  {$ENDIF}
+  Classes, SysUtils;
+
+function GetSystemThreadCount: integer;
+
+{$IFDEF Linux}
+function sysconf(i: cint): clong; cdecl; external name 'sysconf';
+const _SC_NPROCESSORS_ONLN = 83;
+{$ENDIF}
+
+implementation
+
+function GetSystemThreadCount: integer;
+// returns a good default for the number of threads on this system
+{$IF defined(windows)}
+//returns total number of processors available to system including logical hyperthreaded processors
+var
+  SystemInfo: SYSTEM_INFO;
+  {$IFnDEF WinCE}
+  i: Integer;
+  ProcessAffinityMask, SystemAffinityMask: DWORD_PTR;
+  Mask: DWORD;
+  {$ENDIF}
+  test: int64;
+begin
+  QueryPerformanceCounter(test);
+  {$IFnDEF WinCE}
+  if GetProcessAffinityMask(GetCurrentProcess, ProcessAffinityMask{%H-}, SystemAffinityMask{%H-})
+  then begin
+    Result := 0;
+    for i := 0 to 31 do begin
+      Mask := DWord(1) shl i;
+      if (ProcessAffinityMask and Mask)<>0 then
+        inc(Result);
+    end;
+    exit;
+  end;
+  {$ENDIF}
+  //can't get the affinity mask so we just report the total number of processors
+  GetSystemInfo(SystemInfo{%H-});
+  Result := SystemInfo.dwNumberOfProcessors;
+end;
+{$ELSEIF defined(freebsd) or defined(darwin)}
+var
+  mib: array[0..1] of cint;
+  len: cint;
+  t: cint;
+begin
+  mib[0] := CTL_HW;
+  mib[1] := HW_NCPU;
+  len := sizeof(t);
+  {$if FPC_FULLVERSION >= 30101}
+  fpsysctl(@mib, 2, @t, @len, Nil, 0);
+  {$else}
+  fpsysctl(pchar(@mib), 2, @t, @len, Nil, 0);
+  {$endif}
+  Result:=t;
+end;
+{$ELSEIF defined(linux)}
+  begin
+    Result:=sysconf(_SC_NPROCESSORS_ONLN);
+  end;
+{$ELSE}
+  begin
+    Result:=1;
+  end;
+{$ENDIF}
+end.
+


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
This solution implements a multithreaded version written in freepascal (Object Pascal) using an array of 32 bits values to store flags for prime numbers.  
As an array index is 32 bits max in FreePascal, with this approach the addressable bit range on an array storing 32 bits values is actually 2^64.
Bits are used to flag odd numbers only, reducing the memory footprint by half.

Benefits from this approach:

- it passes the test with a sieve size of 10.000.000.000 (including on a Raspberry PI) or any range up to 2^64 - 1 (18.446.744.073.709.551.615), as long as the machine has sufficient memory space,
- performance is significantly better on linux machines (about 33% in average) compared to what I was obtaining with solution 3. However, no performance change on Windows machines.
- I've optimized and inlined the GetBit and ClearBits functions to provide some performance boost.

(I've noticed that using GetMem to allocate memory on the heap for the array, provides better performances than using a setlength instruction in the constructor).

### Solution:

The following 3 simple principles are what has made this solution capable of truly handling 64 bits sieve sizes: 
- bits are stored in an array of 32 bits values, each bit stores a flag for an odd number.
- the Getbit(n) function retrieves a bit value using (pseudo code) ```bits[n >> 6] & (1 << ((n >> 1) & 31)))```, where  
index=n >> 6 (divide by 64 = 2 * 32 as only odd numbers are flagged, and each array element is 32 bits), the bit for the ```&``` operation is shifted left by the modulo 32 of n/2
- the ClearBits(n, skip) method loops from i=n/2 to sizeSize/2 and clears each bit using (pseudo code) ```bits[i>>5]&=~(1<<(i & 31))``` followed by ```i+=skip/2``` to take into account the fact that the bits array stores flags for odd numbers only.
## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
